### PR TITLE
GitHub's get_repo method has parameter to connect or not repository

### DIFF
--- a/gofedlib/repository/githubclient.py
+++ b/gofedlib/repository/githubclient.py
@@ -7,12 +7,12 @@ import requests
 
 class GithubClient(object):
 
-	def __init__(self, username, project):
+	def __init__(self, username, project, lazy=True):
 		self._username = username
 		self._project = project
 		self.github = Github()
 		try:
-			self.repo = self.github.get_repo(username + '/' + project)
+			self.repo = self.github.get_repo(username + '/' + project, lazy)
 		except GithubException as e:
 			raise KeyError('Failed to get repository information: %s' % e)
 

--- a/gofedlib/repository/repositoryclientbuilder.py
+++ b/gofedlib/repository/repositoryclientbuilder.py
@@ -6,10 +6,10 @@ import os
 
 class RepositoryClientBuilder(object):
 
-	def buildWithRemoteClient(self, repo_info):
+	def buildWithRemoteClient(self, repo_info, lazy=True):
 
 		if repo_info['provider'] == 'github':
-			return GithubClient(repo_info['username'], repo_info['project'])
+			return GithubClient(repo_info['username'], repo_info['project'], lazy)
 		if repo_info['provider'] == 'bitbucket':
 			return BitbucketClient(repo_info['username'], repo_info['project'])
 


### PR DESCRIPTION
Add 'lazy' parameter to buildWithRemoteClient method to decide if it should try to connect GitHub repository while getting repository