### PR TITLE
Add CLI flag to skip errors when parsing dependencies

### DIFF
--- a/gofedlib-cli
+++ b/gofedlib-cli
@@ -81,6 +81,8 @@ if __name__ == '__main__':
                     default=None, type=str)
     ap.add_argument('-r', '--raw-project-packages', help="raw output from gofedlib",
                     default=False, action='store_true')
+    ap.add_argument('-s', '--skip-errors', help="Skip errors encountered when parsing project dependencies",
+                    default=False, action='store_true')
 
     args = ap.parse_args()
     result = {}
@@ -106,7 +108,7 @@ if __name__ == '__main__':
             'tests': args.dependencies_tests
         }
 
-        result.update(get_dependencies(project_packages(args.path), selection))
+        result.update(get_dependencies(project_packages(args.path, skip_errors=args.skip_errors), selection))
 
     if args.output:
         with open(args.output, 'w') as f:

--- a/gofedlib/go/functions.py
+++ b/gofedlib/go/functions.py
@@ -4,8 +4,8 @@ from .apidiff.apidiff import GoApiDiff
 def api(source_code_directory):
 	return GoSymbolsExtractor(source_code_directory).extract().exportedApi()
 
-def project_packages(source_code_directory):
-	return GoSymbolsExtractor(source_code_directory).extract().packages()
+def project_packages(source_code_directory, skip_errors=False):
+	return GoSymbolsExtractor(source_code_directory, skip_errors=skip_errors).extract().packages()
 
 def apidiff(api1, api2):
 	return GoApiDiff(api1, api2).runDiff().apiDiff()


### PR DESCRIPTION
Fixes this issue: https://github.com/gofed/gofedlib/issues/17